### PR TITLE
Image stream routes & file extension search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 find_word.py
 doc/build/
 *pyc
+.idea/
+exports.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10
+FROM node:4.4.4
 
 RUN mkdir -p /app
 

--- a/controllers/Medium.js
+++ b/controllers/Medium.js
@@ -25,6 +25,7 @@ SOFTWARE.
 var path = require('path');
 var async = require('async');
 var _ = require('./utils');
+var glob = require('glob-fs')({ gitignore: true });
 
 var Medium = require('../models/Medium');
 var Annotation = require('../models/Annotation');
@@ -193,6 +194,25 @@ var streamFormat = function (req, res, extension) {
       return;
     }
 
+    var globpath = '..' + req.app.get('media') + '/' + medium.url + '.*';
+
+    try {
+      var files = glob.readdirSync(globpath);
+
+      // Ensuite pour chaque fichier, on va déterminer si celui-ci correspond à celui recherché
+      for (i = 0; i < files.length; i++) {
+        var f = files[i]; // Le filename
+        var fsplited = f.split('.');
+
+        if (fsplited[fsplited.length - 1].toLowerCase() === extension.toLowerCase()) {
+          absolutePathToFile = f;
+        }
+      }
+    } catch (e) {
+      console.error('Error: ' + e);
+      console.error('Falling back to default medium path');
+    }
+
     var absolutePathToFile = medium.url + '.' + extension;
     absolutePathToFile = path.join(req.app.get('media'), absolutePathToFile);
     res.status(200).sendFile(
@@ -219,4 +239,20 @@ exports.streamMp4 = function (req, res) {
 
 exports.streamOgv = function (req, res) {
   streamFormat(req, res, 'ogv');
+};
+
+exports.streamImage = function (req, res) {
+  streamFormat(req, res, 'jpg');
+};
+
+exports.streamJpg = function (req, res) {
+  streamFormat(req, res, 'jpg');
+};
+
+exports.streamJpeg = function (req, res) {
+  streamFormat(req, res, 'jpeg');
+};
+
+exports.streamPng = function (req, res) {
+  streamFormat(req, res, 'png');
 };

--- a/controllers/Medium.js
+++ b/controllers/Medium.js
@@ -194,14 +194,16 @@ var streamFormat = function (req, res, extension) {
       return;
     }
 
+    var absolutePathToFile = medium.url + '.' + extension;
+    absolutePathToFile = path.join(req.app.get('media'), absolutePathToFile);
+
     var globpath = '..' + req.app.get('media') + '/' + medium.url + '.*';
 
     try {
       var files = glob.readdirSync(globpath);
 
-      // Ensuite pour chaque fichier, on va déterminer si celui-ci correspond à celui recherché
       for (i = 0; i < files.length; i++) {
-        var f = files[i]; // Le filename
+        var f = files[i];
         var fsplited = f.split('.');
 
         if (fsplited[fsplited.length - 1].toLowerCase() === extension.toLowerCase()) {
@@ -211,10 +213,10 @@ var streamFormat = function (req, res, extension) {
     } catch (e) {
       console.error('Error: ' + e);
       console.error('Falling back to default medium path');
+      absolutePathToFile = medium.url + '.' + extension;
+      absolutePathToFile = path.join(req.app.get('media'), absolutePathToFile);
     }
 
-    var absolutePathToFile = medium.url + '.' + extension;
-    absolutePathToFile = path.join(req.app.get('media'), absolutePathToFile);
     res.status(200).sendFile(
       absolutePathToFile,
       function (error) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "express-session": "^1.11.1",
     "file-stream-rotator": "^0.0.6",
     "forever": "^0.14.1",
+    "glob-fs": "^0.1.6",
     "method-override": "^2.3.2",
     "mongoose": "^4.0.1",
     "morgan": "^1.5.2",

--- a/routes.js
+++ b/routes.js
@@ -285,6 +285,11 @@ exports.initialize = function (app) {
     _.middleware.fExistsWithRights(mMedium, _.READ),
     Medium.stream);
 
+  app.get('/medium/:id_medium/image',
+    Authentication.middleware.isLoggedIn,
+    _.middleware.fExistsWithRights(mMedium, _.READ),
+    Medium.streamImage);
+
   // stream one medium in WebM
   app.get('/medium/:id_medium/webm',
     Authentication.middleware.isLoggedIn,
@@ -302,6 +307,24 @@ exports.initialize = function (app) {
     Authentication.middleware.isLoggedIn,
     _.middleware.fExistsWithRights(mMedium, _.READ),
     Medium.streamOgv);
+
+  // stream one medium in png
+  app.get('/medium/:id_medium/png',
+    Authentication.middleware.isLoggedIn,
+    _.middleware.fExistsWithRights(mMedium, _.READ),
+    Medium.streamPng);
+
+  // stream one medium in jpg
+  app.get('/medium/:id_medium/jpg',
+    Authentication.middleware.isLoggedIn,
+    _.middleware.fExistsWithRights(mMedium, _.READ),
+    Medium.streamJpg);
+
+  // stream one medium in jpeg
+  app.get('/medium/:id_medium/jpeg',
+    Authentication.middleware.isLoggedIn,
+    _.middleware.fExistsWithRights(mMedium, _.READ),
+    Medium.streamJpeg);
 
   // LAYER
 


### PR DESCRIPTION
I cloned this repo today and directly made the changes. It should be easy to see the diff, if it's not good again, tell me

> Note: Node version has been changed from 0.10 to 4.4.4, because the glob library (here) don't support 0.10.
> 
> These commits are changing several things:
> 
> Picture stream routes (streamPng, streamJpg, ...) in the controller
> File extension searching, to allow the requested file A/B/C.MP4 to match the file A/B/C.mp4
