### PR TITLE
Fix default mongodb host in cli doc

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ var Authentication = require('./controllers/Authentication');
 
 program
   .option('--port <port>', 'Local port to listen to (default: 3000)', parseInt)
-  .option('--mongodb-host <host>', 'MongoDB host (default: localhost)')
+  .option('--mongodb-host <host>', 'MongoDB host (default: mongo)')
   .option('--mongodb-port <port>', 'MongoDB port (default: 27017)', parseInt)
   .option('--mongodb-name <dbname>',
     'MongoDB database name (default: camomile)')


### PR DESCRIPTION
It is "mongo" not localhost (see https://github.com/rom1504/camomile-server/blob/27c9450c6006d1e0cdc8acd58382221b58ebc9ec/app.js#L67 )

That was a little bit confusing when running the server without docker.

